### PR TITLE
Supporting range argument on rollup method

### DIFF
--- a/lib/rollup/aggregator.rb
+++ b/lib/rollup/aggregator.rb
@@ -48,24 +48,22 @@ class Rollup
 
       if last
         gd_options[:last] = last
+      elsif range
+        gd_options[:range] = range
       elsif !clear
-        if range
-          gd_options[:range] = range
-        else
-          # if no rollups, compute all intervals
-          # if rollups, recompute last interval
-          max_time = Rollup.unscoped.where(name: name, interval: interval).maximum(Utils.time_sql(interval))
-          if max_time
-            # for MySQL on Ubuntu 18.04 (and likely other platforms)
-            if max_time.is_a?(String)
-              utc = ActiveSupport::TimeZone["Etc/UTC"]
-              max_time = Utils.date_interval?(interval) ? max_time.to_date : utc.parse(max_time).in_time_zone(time_zone)
-            end
-
-            # aligns perfectly if time zone doesn't change
-            # if time zone does change, there are other problems besides this
-            gd_options[:range] = max_time..
+        # if no rollups, compute all intervals
+        # if rollups, recompute last interval
+        max_time = Rollup.unscoped.where(name: name, interval: interval).maximum(Utils.time_sql(interval))
+        if max_time
+          # for MySQL on Ubuntu 18.04 (and likely other platforms)
+          if max_time.is_a?(String)
+            utc = ActiveSupport::TimeZone["Etc/UTC"]
+            max_time = Utils.date_interval?(interval) ? max_time.to_date : utc.parse(max_time).in_time_zone(time_zone)
           end
+
+          # aligns perfectly if time zone doesn't change
+          # if time zone does change, there are other problems besides this
+          gd_options[:range] = max_time..
         end
       end
 

--- a/test/aggregator_test.rb
+++ b/test/aggregator_test.rb
@@ -77,4 +77,16 @@ class AggregatorTest < Minitest::Test
     end
     assert_equal error.message, "Name can't be blank"
   end
+
+  def test_range
+    create_users
+    User.rollup("Test", range: 1.day.ago.all_day)
+
+    expected = {
+      now.to_date - 1 => 2
+    }
+
+    assert_equal expected, Rollup.series("Test")
+  end
+
 end


### PR DESCRIPTION
Using the range argument will be useful for calculating and recalculating rollups
of large data sets that cant be counted all at once