### PR TITLE
Add value precision workaround to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,21 @@ Rollup stores both dates and times in the `time` column depending on the interva
 - MySQL: `CAST(time AS date)`
 - SQLite: `date(time)`
 
+### Value Precision
+
+The default value column is of type `:float` which might not have the precision you need. If you need a different precision you can change the type of the value column like this
+
+```ruby
+# some_migration.rb
+def up
+  change_column :rollups, :value, :decimal, precision: 24, scale: 2
+end
+
+def down
+  change_column :rollups, :value, :float
+end
+```
+
 ## Examples
 
 - [Ahoy](#ahoy)


### PR DESCRIPTION
I encountered rounding errors while summing up large numbers with rollup:

```ruby
[1] pry(main)> MyModel.rollup('my rollup') { |r| r.sum(:my_int_column) }
[2] pry(main)> Rollup.series('my rollup').values.sum == MyModel.pluck(:my_int_column).sum
=> false
```