### PR TITLE
fix: an issue causing timezone:false not to be respected

### DIFF
--- a/lib/rollup/aggregator.rb
+++ b/lib/rollup/aggregator.rb
@@ -43,7 +43,7 @@ class Rollup
       raise ArgumentError, "Cannot use range and current together" if range && !current.nil?
 
       current = true if current.nil?
-      time_zone ||= Rollup.time_zone
+      time_zone = Rollup.time_zone if time_zone.nil?
 
       gd_options = {
         current: current
@@ -68,7 +68,14 @@ class Rollup
           # for MySQL on Ubuntu 18.04 (and likely other platforms)
           if max_time.is_a?(String)
             utc = ActiveSupport::TimeZone["Etc/UTC"]
-            max_time = Utils.date_interval?(interval) ? max_time.to_date : utc.parse(max_time).in_time_zone(time_zone)
+            max_time =
+              if Utils.date_interval?(interval)
+                max_time.to_date
+              else
+                t = utc.parse(max_time)
+                t = t.in_time_zone(time_zone) if time_zone
+                t
+              end
           end
 
           # aligns perfectly if time zone doesn't change


### PR DESCRIPTION
Groupdate has this delightful `time_zone: false` setting that allows you to group by date fields. I like using this in rollup as well, I have a table where I have a date field that the rollup is based on, but my app's TZ is usually somewhere in America. As a result, groupdate casts it to a time in the evening of the day before, and the whole rollup shifts one day backwards.

This PR intends to fix it by ignoring time zones if desired.