### PR TITLE
Add writing_role configuration for database connection switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ Time zone objects also work. To see a list of available time zones in Rails, run
 
 See [date storage](#date-storage) for how dates are stored.
 
+### Multiple Databases
+
+Specify a `writing_role` when you want to explicitly switch the database role when writing the rollup to the database.
+
+```ruby
+Rollup.writing_role = :writing
+```
+
+See [ActiveRecord::Base.connected_to](https://guides.rubyonrails.org/active_record_multiple_databases.html#connecting-to-the-database) for more information.
+
 ### Calculations
 
 Rollups use `count` by default. For other calculations, use:

--- a/lib/rollup.rb
+++ b/lib/rollup.rb
@@ -5,8 +5,8 @@ class Rollup < ActiveRecord::Base
 
   class << self
     attr_accessor :week_start
+    attr_accessor :writing_role
     attr_writer :time_zone
-    attr_writer :writing_role
   end
   self.week_start = :sunday
 

--- a/lib/rollup.rb
+++ b/lib/rollup.rb
@@ -6,6 +6,7 @@ class Rollup < ActiveRecord::Base
   class << self
     attr_accessor :week_start
     attr_writer :time_zone
+    attr_writer :writing_role
   end
   self.week_start = :sunday
 

--- a/lib/rollup/aggregator.rb
+++ b/lib/rollup/aggregator.rb
@@ -19,7 +19,9 @@ class Rollup
       records = prepare_result(result, name, dimension_names, interval)
 
       maybe_clear(clear, name, interval) do
-        save_records(records) if records.any?
+        with_writing_role do
+          save_records(records) if records.any?
+        end
       end
     end
 
@@ -181,6 +183,14 @@ class Rollup
         end
       else
         yield
+      end
+    end
+
+    def with_writing_role(&block)
+      if Rollup.writing_role.present?
+        ActiveRecord::Base.connected_to(role: Rollup.writing_role, &block)
+      else
+        block.call
       end
     end
 

--- a/lib/rollup/model.rb
+++ b/lib/rollup/model.rb
@@ -1,4 +1,6 @@
 class Rollup
+  cattr_accessor :writing_role
+
   module Model
     attr_accessor :rollup_column
 

--- a/lib/rollup/model.rb
+++ b/lib/rollup/model.rb
@@ -1,6 +1,4 @@
 class Rollup
-  cattr_accessor :writing_role
-
   module Model
     attr_accessor :rollup_column
 


### PR DESCRIPTION
This PR fixes #18 by adding a `writing_role` setting that gets used to wrap the `save_records` call in the `rollup` method in. If not configured it'll call and return block directly by default.

Usage could look something like this for the implementing codebase:

```ruby
Rollup.writing_role = :writing

ActiveRecord::Base.connected_to(role: :replica, prevent_writes: true) do
  Invoice.group(:project_id).rollup("Revenue per project") { |i| i.sum(:total_amount_cents) }
end
```

Which would then fetch the data from the replica and then switch to writing the rollup to rollups using the writing role.

I'm very open to a less monkey-patchy way of testing this! And of course to any feedback on the implementation in general.